### PR TITLE
changed client to accept mtu which is used to calculate ideal chunk s…

### DIFF
--- a/example/lib/device.dart
+++ b/example/lib/device.dart
@@ -48,9 +48,7 @@ class _DeviceScreenState extends State<DeviceScreen> {
     final stream = widget.ble.connectToDevice(
       id: widget.device.id,
       servicesWithCharacteristicsToDiscover: {
-        Uuid.parse("8d53dc1d-1db7-4cd3-868b-8a527460aa84"): [
-          Uuid.parse("da2e7828-fbce-4e01-ae9e-261174997c48")
-        ]
+        Uuid.parse("8d53dc1d-1db7-4cd3-868b-8a527460aa84"): [Uuid.parse("da2e7828-fbce-4e01-ae9e-261174997c48")]
       },
       connectionTimeout: widget.connectionTimeout,
     );
@@ -82,21 +80,21 @@ class _DeviceScreenState extends State<DeviceScreen> {
     Client? newClient;
     ImageState? newImageState;
     if (event.connectionState == DeviceConnectionState.connected) {
-      await widget.ble.requestMtu(deviceId: widget.device.id, mtu: 517);
+      final actualMtu = await widget.ble.requestMtu(deviceId: widget.device.id, mtu: 498);
       final characteristic = QualifiedCharacteristic(
         serviceId: Uuid.parse("8d53dc1d-1db7-4cd3-868b-8a527460aa84"),
         characteristicId: Uuid.parse("da2e7828-fbce-4e01-ae9e-261174997c48"),
         deviceId: widget.device.id,
       );
       newClient = Client(
+        mtu: actualMtu,
         input: widget.ble.subscribeToCharacteristic(characteristic).handleError(
           (error) {
             // ignore errors
             // disconnecting causes the stream to end anyways
           },
         ),
-        output: (msg) => widget.ble
-            .writeCharacteristicWithoutResponse(characteristic, value: msg),
+        output: (msg) => widget.ble.writeCharacteristicWithoutResponse(characteristic, value: msg),
       );
       newImageState = await newClient.readImageState(timeout);
     }
@@ -274,16 +272,14 @@ class ImageWidget extends StatelessWidget {
       trailing = TextButton(
         child: const Text("CONFIRM"),
         onPressed: () async {
-          onImageStateChanged(
-              await client.confirmImageState(_DeviceScreenState.timeout));
+          onImageStateChanged(await client.confirmImageState(_DeviceScreenState.timeout));
         },
       );
     } else if (!image.active && !image.pending) {
       trailing = TextButton(
         child: const Text("TEST"),
         onPressed: () async {
-          onImageStateChanged(await client.setPendingImage(
-              image.hash, false, _DeviceScreenState.timeout));
+          onImageStateChanged(await client.setPendingImage(image.hash, false, _DeviceScreenState.timeout));
         },
       );
     }

--- a/test/client.dart
+++ b/test/client.dart
@@ -7,9 +7,9 @@ import 'package:mcumgr/src/smp.dart';
 typedef MockClientHandler = Packet Function(Packet);
 
 class MockClient extends Client {
-  MockClient._create(
-      StreamController<List<int>> controller, MockClientHandler handler)
+  MockClient._create(StreamController<List<int>> controller, MockClientHandler handler)
       : super(
+          mtu: 498,
           input: controller.stream,
           output: (msg) {
             final header = Header.decode(msg);

--- a/test/client_test.dart
+++ b/test/client_test.dart
@@ -41,8 +41,7 @@ void main() {
 
           if (offset == 0) {
             // start
-            final image =
-                (content[CborString("image")] as CborSmallInt).toInt();
+            final image = (content[CborString("image")] as CborSmallInt).toInt();
             final len = (content[CborString("len")] as CborSmallInt).toInt();
             final sha = (content[CborString("sha")] as CborBytes).bytes;
             expect(image, 0);
@@ -79,7 +78,6 @@ void main() {
         localImage,
         localHash,
         Duration(seconds: 1),
-        chunkSize: chunkSize,
       );
       expect(uploadedImage, localImage);
     });


### PR DESCRIPTION
…ize.

With the following configs on a nrf52840 board and mtu=498 in mcumgr: CONFIG_MCUMGR_SMP_REASSEMBLY_BT=y
CONFIG_MCUMGR_BUF_SIZE=2475
CONFIG_OS_MGMT_MCUMGR_PARAMS=y
CONFIG_MCUMGR_BUF_COUNT=4 (default)

CONFIG_BT_L2CAP_TX_MTU=498
CONFIG_BT_BUF_ACL_RX_SIZE=502
CONFIG_BT_BUF_ACL_TX_SIZE=502
CONFIG_BT_CTLR_DATA_LENGTH_MAX=251

you will get a lot higher throughput using this library.

Used https://github.com/NordicSemiconductor/Android-nRF-Connect-Device-Manager as reference for this code.


